### PR TITLE
Fix: Doc formatter contexts

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,9 +13,9 @@ GEM
     diff-lcs (1.4.4)
     method_source (1.0.0)
     parallel (1.20.1)
-    parallel_tests (3.4.0)
+    parallel_tests (3.5.0)
       parallel
-    pry (0.13.1)
+    pry (0.14.0)
       coderay (~> 1.1)
       method_source (~> 1.0)
     rake (12.3.3)
@@ -23,15 +23,15 @@ GEM
       rspec-core (~> 3.10.0)
       rspec-expectations (~> 3.10.0)
       rspec-mocks (~> 3.10.0)
-    rspec-core (3.10.0)
+    rspec-core (3.10.1)
       rspec-support (~> 3.10.0)
-    rspec-expectations (3.10.0)
+    rspec-expectations (3.10.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
-    rspec-mocks (3.10.0)
+    rspec-mocks (3.10.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
-    rspec-support (3.10.0)
+    rspec-support (3.10.2)
 
 PLATFORMS
   ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    turbo_tests (1.2.0)
+    turbo_tests (1.2.1)
       bundler
       parallel_tests (~> 3.3)
       rspec (~> 3.10.0)

--- a/lib/turbo_tests/cli.rb
+++ b/lib/turbo_tests/cli.rb
@@ -17,7 +17,7 @@ module TurboTests
       fail_fast = nil
 
       OptionParser.new { |opts|
-        opts.banner = <<-BANNER.gsub(/^          /, "")
+        opts.banner = <<~BANNER
           Run all tests in parallel, giving each process ENV['TEST_ENV_NUMBER'] ('1', '2', '3', ...).
 
           Uses parallel_tests under the hood, but reports test results incrementally. Based on Discourse and RubyGems work in this area.

--- a/lib/turbo_tests/json_rows_formatter.rb
+++ b/lib/turbo_tests/json_rows_formatter.rb
@@ -41,7 +41,7 @@ module TurboTests
     def example_group_started(notification)
       output_row(
         "type" => :group_started,
-        "example" => group_to_json(notification)
+        "group" => group_to_json(notification)
       )
     end
 

--- a/lib/turbo_tests/json_rows_formatter.rb
+++ b/lib/turbo_tests/json_rows_formatter.rb
@@ -26,6 +26,9 @@ module TurboTests
       :example_failed,
       :example_passed,
       :example_pending,
+      :example_group_started,
+      :example_group_finished,
+      :example_pending,
       :seed
     )
 
@@ -33,6 +36,20 @@ module TurboTests
 
     def initialize(output)
       @output = output
+    end
+
+    def example_group_started(notification)
+      output_row(
+        "type" => :group_started,
+        "example" => group_to_json(notification)
+      )
+    end
+
+    def example_group_finished(notification)
+      output_row(
+        "type" => :group_finished,
+        "example" => group_to_json(notification)
+      )
     end
 
     def example_passed(notification)
@@ -110,6 +127,14 @@ module TurboTests
             example.metadata[:shared_group_inclusion_backtrace].map { |frame| stack_frame_to_json(frame) }
         },
         "location_rerun_argument" => example.location_rerun_argument
+      }
+    end
+
+    def group_to_json(notification)
+      {
+        "group": {
+          "description": notification.group.description
+        }
       }
     end
 

--- a/lib/turbo_tests/reporter.rb
+++ b/lib/turbo_tests/reporter.rb
@@ -45,6 +45,14 @@ module TurboTests
       end
     end
 
+    def group_started(notification)
+      delegate_to_formatters(:example_group_started, notification)
+    end
+
+    def group_finished
+      delegate_to_formatters(:example_group_finished, nil)
+    end
+
     def example_passed(example)
       delegate_to_formatters(:example_passed, example.notification)
 
@@ -66,7 +74,8 @@ module TurboTests
     end
 
     def finish
-      end_time = Time.now
+      # SEE: https://bit.ly/2NP87Cz
+      end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
       delegate_to_formatters(:start_dump,
         RSpec::Core::Notifications::NullNotification)

--- a/lib/turbo_tests/runner.rb
+++ b/lib/turbo_tests/runner.rb
@@ -7,6 +7,8 @@ require_relative "../utils/hash_extension"
 
 module TurboTests
   class Runner
+    using CoreExtensions
+
     def self.run(opts = {})
       files = opts[:files]
       formatters = opts[:formatters]

--- a/lib/turbo_tests/runner.rb
+++ b/lib/turbo_tests/runner.rb
@@ -3,13 +3,17 @@
 require "json"
 require "parallel_tests/rspec/runner"
 
+require_relative "../utils/hash_extension"
+
 module TurboTests
   class Runner
     def self.run(opts = {})
       files = opts[:files]
       formatters = opts[:formatters]
       tags = opts[:tags]
-      start_time = opts.fetch(:start_time) { Time.now }
+
+      # SEE: https://bit.ly/2NP87Cz
+      start_time = opts.fetch(:start_time) { Process.clock_gettime(Process::CLOCK_MONOTONIC) }
       verbose = opts.fetch(:verbose, false)
       fail_fast = opts.fetch(:fail_fast, nil)
       count = opts.fetch(:count, nil)
@@ -157,6 +161,10 @@ module TurboTests
         when "example_passed"
           example = FakeExample.from_obj(message["example"])
           @reporter.example_passed(example)
+        when "group_started"
+          @reporter.group_started(message["example"].to_struct)
+        when "group_finished"
+          @reporter.group_finished
         when "example_pending"
           example = FakeExample.from_obj(message["example"])
           @reporter.example_pending(example)

--- a/lib/turbo_tests/runner.rb
+++ b/lib/turbo_tests/runner.rb
@@ -164,7 +164,7 @@ module TurboTests
           example = FakeExample.from_obj(message["example"])
           @reporter.example_passed(example)
         when "group_started"
-          @reporter.group_started(message["example"].to_struct)
+          @reporter.group_started(message["group"].to_struct)
         when "group_finished"
           @reporter.group_finished
         when "example_pending"

--- a/lib/turbo_tests/version.rb
+++ b/lib/turbo_tests/version.rb
@@ -1,3 +1,3 @@
 module TurboTests
-  VERSION = "1.2.0"
+  VERSION = "1.2.1"
 end

--- a/lib/utils/hash_extension.rb
+++ b/lib/utils/hash_extension.rb
@@ -1,7 +1,9 @@
-class Hash
-  def to_struct
-    OpenStruct.new(self.each_with_object({}) do |(key, val), acc|
-      acc[key] = val.is_a?(Hash) ? val.to_struct : val
-    end)
+module CoreExtensions
+  refine Hash do
+    def to_struct
+      OpenStruct.new(self.each_with_object({}) do |(key, val), acc|
+        acc[key] = val.is_a?(Hash) ? val.to_struct : val
+      end)
+    end
   end
 end

--- a/lib/utils/hash_extension.rb
+++ b/lib/utils/hash_extension.rb
@@ -1,0 +1,7 @@
+class Hash
+  def to_struct
+    OpenStruct.new(self.each_with_object({}) do |(key, val), acc|
+      acc[key] = val.is_a?(Hash) ? val.to_struct : val
+    end)
+  end
+end

--- a/spec/doc_formatter_spec.rb
+++ b/spec/doc_formatter_spec.rb
@@ -1,0 +1,11 @@
+RSpec.describe "Top-level context" do
+  describe "#instance_method" do
+    it "does what it's supposed to" do
+      expect(true).to be_truthy
+    end
+
+    it "doesn't do what it isn't supposed to" do
+      expect(false).not_to be_truthy
+    end
+  end
+end


### PR DESCRIPTION
This PR addresses an issue https://github.com/serpapi/turbo_tests/issues/3 by adding the context output with proper indentation through RSpec's standard `DocumentationFormatter` methods.

I added the sample code right to the specs to simplify at least the visual validation of the solution. You can test it by running:

```shell
bundler exec turbo_tests --format=documentation
```

Which with this fix in place is supposed to output the following:

![image](https://user-images.githubusercontent.com/455338/109420483-68eb9380-79db-11eb-916b-d8f6bf7932e7.png)
