### PR TITLE
Fix: Loading time summary not being reflected in the report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,60 @@
 
 # rspec failure tracking
 .rspec_status
+
+
+# Created by https://www.toptal.com/developers/gitignore/api/macos,vim
+# Edit at https://www.toptal.com/developers/gitignore?templates=macos,vim
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### Vim ###
+# Swap
+[._]*.s[a-v][a-z]
+!*.svg  # comment out if you don't need vector files
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+
+# Session
+Session.vim
+Sessionx.vim
+
+# Temporary
+.netrwhist
+*~
+# Auto-generated tag files
+tags
+# Persistent undo
+[._]*.un~
+
+# End of https://www.toptal.com/developers/gitignore/api/macos,vim
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    turbo_tests (1.2.1)
+    turbo_tests (1.2.2)
       bundler
       parallel_tests (~> 3.3)
       rspec (~> 3.10.0)

--- a/lib/turbo_tests/json_rows_formatter.rb
+++ b/lib/turbo_tests/json_rows_formatter.rb
@@ -22,6 +22,7 @@ module TurboTests
   class JsonRowsFormatter
     RSpec::Core::Formatters.register(
       self,
+      :start,
       :close,
       :example_failed,
       :example_passed,
@@ -33,6 +34,13 @@ module TurboTests
 
     def initialize(output)
       @output = output
+    end
+
+    def start(notification)
+      output_row(
+        "type" => :load_summary,
+        "summary" => load_summary_to_json(notification)
+      )
     end
 
     def example_passed(notification)
@@ -110,6 +118,13 @@ module TurboTests
             example.metadata[:shared_group_inclusion_backtrace].map { |frame| stack_frame_to_json(frame) }
         },
         "location_rerun_argument" => example.location_rerun_argument
+      }
+    end
+
+    def load_summary_to_json(notification)
+      {
+        count: notification.count,
+        load_time: notification.load_time
       }
     end
 

--- a/lib/turbo_tests/reporter.rb
+++ b/lib/turbo_tests/reporter.rb
@@ -2,6 +2,8 @@
 
 module TurboTests
   class Reporter
+    attr_writer :load_time
+
     def self.from_config(formatter_config, start_time)
       reporter = new(start_time)
 
@@ -27,6 +29,7 @@ module TurboTests
       @failed_examples = []
       @all_examples = []
       @start_time = start_time
+      @load_time = 0
     end
 
     def add(name, outputs)
@@ -84,7 +87,7 @@ module TurboTests
           @all_examples,
           @failed_examples,
           @pending_examples,
-          0,
+          @load_time,
           0
         ))
       delegate_to_formatters(:close,

--- a/lib/turbo_tests/runner.rb
+++ b/lib/turbo_tests/runner.rb
@@ -33,6 +33,8 @@ module TurboTests
       @verbose = opts[:verbose]
       @fail_fast = opts[:fail_fast]
       @count = opts[:count]
+      @load_time = 0
+      @load_count = 0
 
       @failure_count = 0
       @runtime_log = "tmp/parallel_runtime_rspec.log"
@@ -160,6 +162,9 @@ module TurboTests
         when "example_pending"
           example = FakeExample.from_obj(message["example"])
           @reporter.example_pending(example)
+        when "load_summary"
+          message = message["summary"]
+          @reporter.load_time = message["load_time"] if message.fetch("count", 0) > @load_count
         when "example_failed"
           example = FakeExample.from_obj(message["example"])
           @reporter.example_failed(example)

--- a/lib/turbo_tests/runner.rb
+++ b/lib/turbo_tests/runner.rb
@@ -164,6 +164,8 @@ module TurboTests
           @reporter.example_pending(example)
         when "load_summary"
           message = message["summary"]
+          # NOTE: notifications order and content is not guaranteed hence the fetch
+          #       and count increment tracking to get the latest accumulated load time
           @reporter.load_time = message["load_time"] if message.fetch("count", 0) > @load_count
         when "example_failed"
           example = FakeExample.from_obj(message["example"])

--- a/lib/turbo_tests/runner.rb
+++ b/lib/turbo_tests/runner.rb
@@ -210,7 +210,7 @@ module TurboTests
 
       num_processes = groups.size
       num_tests = groups.map(&:size).sum
-      tests_per_process = (num_processes == 0 ? 0 : num_tests / num_processes)
+      tests_per_process = (num_processes == 0 ? 0 : num_tests.to_f / num_processes).round
 
       puts "#{num_processes} processes for #{num_tests} #{name}s, ~ #{tests_per_process} #{name}s per process"
     end

--- a/lib/turbo_tests/version.rb
+++ b/lib/turbo_tests/version.rb
@@ -1,3 +1,3 @@
 module TurboTests
-  VERSION = "1.2.1"
+  VERSION = "1.2.2"
 end

--- a/spec/doc_formatter_spec.rb
+++ b/spec/doc_formatter_spec.rb
@@ -1,3 +1,5 @@
+# This delay visualizes the effect of load time calculation.
+# https://github.com/serpapi/turbo_tests/pull/8#issue-583037321
 sleep 3
 
 RSpec.describe "Top-level context" do

--- a/spec/doc_formatter_spec.rb
+++ b/spec/doc_formatter_spec.rb
@@ -1,3 +1,5 @@
+sleep 3
+
 RSpec.describe "Top-level context" do
   describe "#instance_method" do
     it "does what it's supposed to" do


### PR DESCRIPTION
This PR fixes the issue https://github.com/serpapi/turbo_tests/issues/1 about capturing the file load time.

To visualize the effect I added a slight delay in the spec, which gets evaluated on loading, therefore adding more loading time which gets correctly reflected in the summary report.

Additionally I took the liberty of improving the rounding of "specs per process" value, e.g. with 7 specs and 4 processes now it reports ~2 specs per process. 😊

Lastly, I merged in my previous PR https://github.com/serpapi/turbo_tests/pull/7, resolved the conflicts, and bumped the version relative to the current master.