### PR TITLE
Fix reporting of pending exceptions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,10 @@
 PATH
   remote: .
   specs:
-    turbo_tests (1.2.4)
+    turbo_tests (1.2.5)
       bundler
       parallel_tests (~> 3.3)
-      rspec (~> 3.10.0)
+      rspec (~> 3.10)
 
 GEM
   remote: https://rubygems.org/
@@ -13,12 +13,12 @@ GEM
     diff-lcs (1.4.4)
     method_source (1.0.0)
     parallel (1.20.1)
-    parallel_tests (3.5.2)
+    parallel_tests (3.7.0)
       parallel
-    pry (0.14.0)
+    pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    rake (13.0.3)
+    rake (13.0.6)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
       rspec-expectations (~> 3.10.0)

--- a/fixtures/rspec/pending_exceptions_spec.rb
+++ b/fixtures/rspec/pending_exceptions_spec.rb
@@ -1,0 +1,15 @@
+RSpec.describe "Fixture of spec file with pending failed examples" do
+  it "is implemented but skipped with 'pending'" do
+    pending("TODO: skipped with 'pending'")
+
+    expect(2).to eq(3)
+  end
+
+  it "is implemented but skipped with 'skip'", skip: "TODO: skipped with 'skip'" do
+    expect(100).to eq(500)
+  end
+
+  xit "is implemented but skipped with 'xit'" do
+    expect(1).to eq(42)
+  end
+end

--- a/lib/turbo_tests.rb
+++ b/lib/turbo_tests.rb
@@ -36,7 +36,7 @@ module TurboTests
     end
   end
 
-  FakeExecutionResult = Struct.new(:example_skipped?, :pending_message, :status, :pending_fixed?, :exception)
+  FakeExecutionResult = Struct.new(:example_skipped?, :pending_message, :status, :pending_fixed?, :exception, :pending_exception)
   class FakeExecutionResult
     def self.from_obj(obj)
       new(
@@ -44,6 +44,7 @@ module TurboTests
         obj[:pending_message],
         obj[:status].to_sym,
         obj[:pending_fixed?],
+        FakeException.from_obj(obj[:exception]),
         FakeException.from_obj(obj[:exception])
       )
     end

--- a/lib/turbo_tests/json_rows_formatter.rb
+++ b/lib/turbo_tests/json_rows_formatter.rb
@@ -29,7 +29,6 @@ module TurboTests
       :example_pending,
       :example_group_started,
       :example_group_finished,
-      :example_pending,
       :message,
       :seed
     )
@@ -121,7 +120,7 @@ module TurboTests
         pending_message: result.pending_message,
         status: result.status,
         pending_fixed?: result.pending_fixed?,
-        exception: exception_to_json(result.exception)
+        exception: exception_to_json(result.exception || result.pending_exception)
       }
     end
 

--- a/lib/turbo_tests/reporter.rb
+++ b/lib/turbo_tests/reporter.rb
@@ -11,7 +11,7 @@ module TurboTests
         name, outputs = config.values_at(:name, :outputs)
 
         outputs.map! do |filename|
-          filename == "-" ? STDOUT : File.open(filename, "w")
+          filename == "-" ? $stdout : File.open(filename, "w")
         end
 
         reporter.add(name, outputs)

--- a/lib/turbo_tests/version.rb
+++ b/lib/turbo_tests/version.rb
@@ -1,3 +1,3 @@
 module TurboTests
-  VERSION = "1.2.4"
+  VERSION = "1.2.5"
 end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -1,23 +1,72 @@
 RSpec.describe TurboTests::CLI do
-  let(:expected_start_of_output) {
-%(1 processes for 1 specs, ~ 1 specs per process
+  subject(:output) { `bundle exec turbo_tests -f d #{fixture}`.strip }
 
-An error occurred while loading ./fixtures/rspec/errors_outside_of_examples_spec.rb.
+  before { output }
+
+  context "errors outside of examples" do
+    let(:expected_start_of_output) {
+      %(
+1 processes for 1 specs, ~ 1 specs per process
+
+An error occurred while loading #{fixture}.
 \e[31mFailure/Error: \e[0m\e[1;34m1\e[0m / \e[1;34m0\e[0m\e[0m
 \e[31m\e[0m
 \e[31mZeroDivisionError:\e[0m
 \e[31m  divided by 0\e[0m
-\e[36m# ./fixtures/rspec/errors_outside_of_examples_spec.rb:4:in `/'\e[0m
-\e[36m# ./fixtures/rspec/errors_outside_of_examples_spec.rb:4:in `block in <top (required)>'\e[0m
-\e[36m# ./fixtures/rspec/errors_outside_of_examples_spec.rb:1:in `<top (required)>'\e[0m).strip
-  }
+\e[36m# #{fixture}:4:in `/'\e[0m
+\e[36m# #{fixture}:4:in `block in <top (required)>'\e[0m
+\e[36m# #{fixture}:1:in `<top (required)>'\e[0m
+).strip
+    }
 
-  it "reports errors outside of examples" do
-    output = `bundle exec turbo_tests ./fixtures/rspec/errors_outside_of_examples_spec.rb`.strip
+    let(:fixture) { "./fixtures/rspec/errors_outside_of_examples_spec.rb" }
 
-    expect($?.exitstatus).to eql(1)
+    it "reports" do
+      expect($?.exitstatus).to eql(1)
 
-    expect(output).to start_with(expected_start_of_output)
-    expect(output).to end_with("0 examples, 0 failures")
+      expect(output).to start_with(expected_start_of_output)
+      expect(output).to end_with("0 examples, 0 failures")
+    end
+  end
+
+  context "pending exceptions", :aggregate_failures do
+    let(:fixture) { "./fixtures/rspec/pending_exceptions_spec.rb" }
+
+    it "reports" do
+      expect($?.exitstatus).to eql(0)
+
+      [
+        "is implemented but skipped with 'pending' (PENDING: TODO: skipped with 'pending')",
+        "is implemented but skipped with 'skip' (PENDING: TODO: skipped with 'skip')",
+        "is implemented but skipped with 'xit' (PENDING: Temporarily skipped with xit)",
+
+        "Pending: (Failures listed here are expected and do not affect your suite's status)",
+
+        %{
+Fixture of spec file with pending failed examples is implemented but skipped with 'pending'
+     # TODO: skipped with 'pending'
+     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
+
+       expected: 3
+            got: 2
+
+       (compared using ==)
+        }.strip,
+
+        %(
+Fixture of spec file with pending failed examples is implemented but skipped with 'skip'
+     # TODO: skipped with 'skip'
+        ).strip,
+
+        %(
+Fixture of spec file with pending failed examples is implemented but skipped with 'xit'
+     # Temporarily skipped with xit
+        ).strip
+      ].each do |part|
+        expect(output).to include(part)
+      end
+
+      expect(output).to end_with("3 examples, 0 failures, 3 pending")
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,5 +10,7 @@ RSpec.configure do |config|
 
   config.expect_with :rspec do |c|
     c.syntax = :expect
+
+    c.max_formatted_output_length = 200
   end
 end

--- a/turbo_tests.gemspec
+++ b/turbo_tests.gemspec
@@ -14,9 +14,9 @@ Gem::Specification.new do |spec|
   spec.metadata["source_code_uri"] = "https://github.com/serpapi/turbo_tests"
   spec.metadata["changelog_uri"] = "https://github.com/serpapi/turbo_tests/releases"
 
-  spec.required_ruby_version = ">= 2.4.0"
+  spec.required_ruby_version = ">= 2.4"
 
-  spec.add_dependency "rspec", "~> 3.10.0"
+  spec.add_dependency "rspec", "~> 3.10"
   spec.add_dependency "parallel_tests", "~> 3.3"
 
   spec.add_development_dependency "pry", "~> 0.14"


### PR DESCRIPTION
Fixes https://github.com/serpapi/turbo_tests/issues/6.

Probably it's time to remove `FakeExample`, `FakeExecutionResult` and use [`RSpec::Core::Example`](https://github.com/rspec/rspec-core/blob/dc898adc3f98d841a43e22cdf62ae2250266c7b6/lib/rspec/core/example.rb#L44), [`RSpec::Core::Example::ExecutionResult`](https://github.com/rspec/rspec-core/blob/dc898adc3f98d841a43e22cdf62ae2250266c7b6/lib/rspec/core/example.rb#L553) and so on. Fake structures were copied from [Discourse source code](https://github.com/discourse/discourse/blob/b1363755827b6701930007ab10ca061ba389480e/lib/turbo_tests.rb#L19-L87).

Thanks to @louim for the reproducible example and an attempt to fix it. Feel free to review this PR.