### PR TITLE
add --create flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ Or install it yourself as:
 $ gem install turbo_tests
 ```
 
+## Setup
+
+Create test databases
+
+```bash
+$ bundle exec turbo_tests --create
+```
+
 ## Usage
 
 Execute tests:
@@ -85,6 +93,7 @@ Options:
         --runtime-log FILE           Location of previously recorded test runtimes
     -v, --verbose                    More output
         --fail-fast=[N]
+        --create                     Create test databases
 ```
 
 ## Development

--- a/lib/turbo_tests/cli.rb
+++ b/lib/turbo_tests/cli.rb
@@ -16,6 +16,7 @@ module TurboTests
       runtime_log = nil
       verbose = false
       fail_fast = nil
+      create = false
 
       OptionParser.new { |opts|
         opts.banner = <<~BANNER
@@ -76,7 +77,15 @@ module TurboTests
           end
           fail_fast = n.nil? || n < 1 ? 1 : n
         end
+
+        opts.on("--create", "Create databases") do
+          create = true
+        end
       }.parse!(@argv)
+
+      if create
+        return TurboTests::Runner.create(count)
+      end
 
       requires.each { |f| require(f) }
 

--- a/lib/turbo_tests/runner.rb
+++ b/lib/turbo_tests/runner.rb
@@ -2,12 +2,20 @@
 
 require "json"
 require "parallel_tests/rspec/runner"
+require "parallel_tests/tasks"
 
 require_relative "../utils/hash_extension"
 
 module TurboTests
   class Runner
     using CoreExtensions
+
+    def self.create(count)
+      ENV["PARALLEL_TEST_FIRST_IS_1"] = "true"
+      command = ["bundle", "exec", "rake", "db:create", "RAILS_ENV=#{ParallelTests::Tasks.rails_env}"]
+      args = { count: count.to_s }
+      ParallelTests::Tasks.run_in_parallel(command, args)
+    end
 
     def self.run(opts = {})
       files = opts[:files]

--- a/spec/turbo_tests_spec.rb
+++ b/spec/turbo_tests_spec.rb
@@ -2,4 +2,26 @@ RSpec.describe TurboTests do
   it "has a version number" do
     expect(TurboTests::VERSION).not_to be nil
   end
+
+  describe "create" do
+    context "with nil count" do
+      it "creates databases" do
+        expect(ParallelTests::Tasks)
+          .to receive(:run_in_parallel)
+          .with(["bundle", "exec", "rake", "db:create", "RAILS_ENV=test"], {:count=>""})
+
+        TurboTests::Runner.create(nil)
+      end
+    end
+
+    context "with count" do
+      it "creates databases" do
+        expect(ParallelTests::Tasks)
+          .to receive(:run_in_parallel)
+          .with(["bundle", "exec", "rake", "db:create", "RAILS_ENV=test"], {:count=>"4"})
+
+        TurboTests::Runner.create(4)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Improve the initial setup experience by allowing the user to run `bundle exec turbo_tests --create` to create the databases, and document this onboarding process. This may help with #12 being less of a hurdle for users coming over from parallel_tests, as well as brand new users.