### PR TITLE
fix: support reporting extra failure lines

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,4 +42,4 @@ DEPENDENCIES
   turbo_tests!
 
 BUNDLED WITH
-   2.2.27
+   2.4.4

--- a/fixtures/rspec/failing_spec.rb
+++ b/fixtures/rspec/failing_spec.rb
@@ -1,0 +1,13 @@
+RSpec.describe "Failing example group" do
+  after(:each) do |example|
+    example.metadata[:extra_failure_lines] ||= []
+
+    lines = example.metadata[:extra_failure_lines]
+
+    lines << "Test info in extra_failure_lines"
+  end
+
+  it "fails" do
+    expect(2).to eq(3)
+  end
+end

--- a/lib/turbo_tests/json_rows_formatter.rb
+++ b/lib/turbo_tests/json_rows_formatter.rb
@@ -141,9 +141,10 @@ module TurboTests
           shared_group_inclusion_backtrace:
             example
               .metadata[:shared_group_inclusion_backtrace]
-              .map { |frame| stack_frame_to_json(frame) }
+              .map { |frame| stack_frame_to_json(frame) },
+          extra_failure_lines: example.metadata[:extra_failure_lines],
         },
-        location_rerun_argument: example.location_rerun_argument
+        location_rerun_argument: example.location_rerun_argument,
       }
     end
 

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -69,4 +69,14 @@ Fixture of spec file with pending failed examples is implemented but skipped wit
       expect(output).to end_with("3 examples, 0 failures, 3 pending")
     end
   end
+
+  describe "extra_failure_lines" do
+    let(:fixture) { "./fixtures/rspec/failing_spec.rb" }
+
+    it "outputs extra_failure_lines" do
+      expect($?.exitstatus).to eql(1)
+
+      expect(output).to include("Test info in extra_failure_lines")
+    end
+  end
 end


### PR DESCRIPTION
Ported from Discourse: https://github.com/discourse/discourse/pull/19637/

Example usage:

```ruby
# spec_helper.rb
config.after(:each) do |example|
  lines = example.metadata[:extra_failure_lines] ||= []

  lines << "Test info in extra_failure_lines"
end
```

RSpec adds `extra_failure_lines` to output: https://github.com/rspec/rspec-core/blob/79ec0fd5b5ebd13031a10960f293b8a4a43cb734/lib/rspec/core/formatters/exception_presenter.rb#L161