### PR TITLE
fix: don't duplicate blank `extra_failure_lines`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,16 +1,16 @@
 PATH
   remote: .
   specs:
-    turbo_tests (1.4.0)
+    turbo_tests (1.4.1)
       bundler (>= 2.1)
       parallel_tests (~> 3.3)
-      rspec (~> 3.10)
+      rspec (>= 3.10)
 
 GEM
   remote: https://rubygems.org/
   specs:
     coderay (1.1.3)
-    diff-lcs (1.4.4)
+    diff-lcs (1.5.0)
     method_source (1.0.0)
     parallel (1.21.0)
     parallel_tests (3.7.3)
@@ -19,19 +19,19 @@ GEM
       coderay (~> 1.1)
       method_source (~> 1.0)
     rake (13.0.6)
-    rspec (3.10.0)
-      rspec-core (~> 3.10.0)
-      rspec-expectations (~> 3.10.0)
-      rspec-mocks (~> 3.10.0)
-    rspec-core (3.10.1)
-      rspec-support (~> 3.10.0)
-    rspec-expectations (3.10.1)
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
+    rspec-core (3.12.1)
+      rspec-support (~> 3.12.0)
+    rspec-expectations (3.12.2)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.10.0)
-    rspec-mocks (3.10.2)
+      rspec-support (~> 3.12.0)
+    rspec-mocks (3.12.3)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.10.0)
-    rspec-support (3.10.2)
+      rspec-support (~> 3.12.0)
+    rspec-support (3.12.0)
 
 PLATFORMS
   ruby

--- a/lib/turbo_tests/version.rb
+++ b/lib/turbo_tests/version.rb
@@ -1,3 +1,3 @@
 module TurboTests
-  VERSION = "1.4.0"
+  VERSION = "1.4.1"
 end

--- a/turbo_tests.gemspec
+++ b/turbo_tests.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.6"
 
-  spec.add_dependency "rspec", "~> 3.10"
+  spec.add_dependency "rspec", ">= 3.10"
   spec.add_dependency "parallel_tests", "~> 3.3"
 
   spec.add_development_dependency "pry", "~> 0.14"


### PR DESCRIPTION
Fix was made in `rspec-core`: https://github.com/rspec/rspec-core/pull/3006