### PR TITLE
Claim compatibility with parallel_tests v4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: [ 2.6, 2.7, 3.0, 3.1, 3.2 ]
+        ruby: [ 2.7, 3.0, 3.1, 3.2 ]
 
     steps:
       - uses: actions/checkout@v3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    turbo_tests (1.4.1)
+    turbo_tests (2.0.0)
       bundler (>= 2.1)
       parallel_tests (>= 3.3.0, < 5)
       rspec (>= 3.10)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     turbo_tests (1.4.1)
       bundler (>= 2.1)
-      parallel_tests (~> 3.3)
+      parallel_tests (>= 3.3.0, < 5)
       rspec (>= 3.10)
 
 GEM
@@ -12,10 +12,10 @@ GEM
     coderay (1.1.3)
     diff-lcs (1.5.0)
     method_source (1.0.0)
-    parallel (1.21.0)
-    parallel_tests (3.7.3)
+    parallel (1.22.1)
+    parallel_tests (4.2.0)
       parallel
-    pry (0.14.1)
+    pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
     rake (13.0.6)
@@ -28,7 +28,7 @@ GEM
     rspec-expectations (3.12.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-mocks (3.12.3)
+    rspec-mocks (3.12.4)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.0)
@@ -42,4 +42,4 @@ DEPENDENCIES
   turbo_tests!
 
 BUNDLED WITH
-   2.4.4
+   2.4.6

--- a/lib/turbo_tests/version.rb
+++ b/lib/turbo_tests/version.rb
@@ -1,3 +1,3 @@
 module TurboTests
-  VERSION = "1.4.1"
+  VERSION = "2.0.0"
 end

--- a/turbo_tests.gemspec
+++ b/turbo_tests.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.metadata["source_code_uri"] = "https://github.com/serpapi/turbo_tests"
   spec.metadata["changelog_uri"] = "https://github.com/serpapi/turbo_tests/releases"
 
-  spec.required_ruby_version = ">= 2.6"
+  spec.required_ruby_version = ">= 2.7"
 
   spec.add_dependency "rspec", ">= 3.10"
   spec.add_dependency "parallel_tests", ">= 3.3.0", "< 5"

--- a/turbo_tests.gemspec
+++ b/turbo_tests.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.6"
 
   spec.add_dependency "rspec", ">= 3.10"
-  spec.add_dependency "parallel_tests", "~> 3.3"
+  spec.add_dependency "parallel_tests", ">= 3.3.0", "< 5"
 
   spec.add_development_dependency "pry", "~> 0.14"
 


### PR DESCRIPTION
As requested, this relaxes the dependency constraint to also allow installation with `parallel_tests` v4.

A hypothetical v5 release will not be installed automatically, until whitelisted.

Fixes #28.