### PR TITLE
Add turbo-tests logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 ![Tests](https://github.com/serpapi/turbo_tests/workflows/Tests/badge.svg)
 
-# TurboTests
+<h1 align="center">
+  TurboTests
+</h1>
+
+<div align="center">
+   <img src="https://user-images.githubusercontent.com/78694043/233910064-87a6d557-1120-42d2-b965-2a9403c6f2f4.svg" width="500" alt="Turbo-Tests">
+</div>
 
 `turbo_tests` is a drop-in replacement for [`grosser/parallel_tests`](https://github.com/grosser/parallel_tests) with incremental summarized output. Source code of this gem is based on [Discourse](https://github.com/discourse/discourse/blob/6b9784cf8a18636bce281a7e4d18e65a0cbc6290/lib/turbo_tests.rb) and [RubyGems](https://github.com/rubygems/rubygems/tree/390335ceb351668cd433bd5bb9823dd021f82533/bundler/tool) work in this area.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 <div align="center">
 
-  <a href="">![Tests](https://github.com/serpapi/turbo_tests/workflows/Tests/badge.svg)</a>
+  ![Tests](https://github.com/serpapi/turbo_tests/workflows/Tests/badge.svg)
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,16 @@
-![Tests](https://github.com/serpapi/turbo_tests/workflows/Tests/badge.svg)
-
 <h1 align="center">
   TurboTests
 </h1>
 
 <div align="center">
    <img src="https://user-images.githubusercontent.com/78694043/233910064-87a6d557-1120-42d2-b965-2a9403c6f2f4.svg" width="500" alt="Turbo-Tests">
+  
+</div>
+
+<div align="center">
+
+  <a href="">![Tests](https://github.com/serpapi/turbo_tests/workflows/Tests/badge.svg)</a>
+
 </div>
 
 `turbo_tests` is a drop-in replacement for [`grosser/parallel_tests`](https://github.com/grosser/parallel_tests) with incremental summarized output. Source code of this gem is based on [Discourse](https://github.com/discourse/discourse/blob/6b9784cf8a18636bce281a7e4d18e65a0cbc6290/lib/turbo_tests.rb) and [RubyGems](https://github.com/rubygems/rubygems/tree/390335ceb351668cd433bd5bb9823dd021f82533/bundler/tool) work in this area.


### PR DESCRIPTION
This PR adds a logo for `turbo_tests`, and centers tests workflow badge under the repo logo.

Logo `width="500"` could be adjusted. Currently (this PR), it looks something like this:

![image](https://user-images.githubusercontent.com/78694043/233912297-3f0b7bad-ed20-435d-a9e9-75d484e50e95.png)
