### PR TITLE
Add seed parameter to turbo tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <div align="center">
    <img src="https://user-images.githubusercontent.com/78694043/233910064-87a6d557-1120-42d2-b965-2a9403c6f2f4.svg" width="500" alt="Turbo-Tests">
-  
+
 </div>
 
 <div align="center">
@@ -96,6 +96,7 @@ Options:
         --runtime-log FILE           Location of previously recorded test runtimes
     -v, --verbose                    More output
         --fail-fast=[N]
+        --seed SEED                  Seed for rspec
 ```
 
 ## Development

--- a/lib/turbo_tests/cli.rb
+++ b/lib/turbo_tests/cli.rb
@@ -78,7 +78,7 @@ module TurboTests
           fail_fast = n.nil? || n < 1 ? 1 : n
         end
 
-        opts.on("--seed SEED", ) do |s|
+        opts.on("--seed SEED", "Seed for rspec") do |s|
           seed = s
         end
       }.parse!(@argv)

--- a/lib/turbo_tests/cli.rb
+++ b/lib/turbo_tests/cli.rb
@@ -16,6 +16,7 @@ module TurboTests
       runtime_log = nil
       verbose = false
       fail_fast = nil
+      seed = nil
 
       OptionParser.new { |opts|
         opts.banner = <<~BANNER
@@ -76,6 +77,10 @@ module TurboTests
           end
           fail_fast = n.nil? || n < 1 ? 1 : n
         end
+
+        opts.on("--seed SEED", ) do |s|
+          seed = s
+        end
       }.parse!(@argv)
 
       requires.each { |f| require(f) }
@@ -101,6 +106,7 @@ module TurboTests
         verbose: verbose,
         fail_fast: fail_fast,
         count: count,
+        seed: seed
       )
 
       if success

--- a/lib/turbo_tests/reporter.rb
+++ b/lib/turbo_tests/reporter.rb
@@ -114,6 +114,11 @@ module TurboTests
         RSpec::Core::Notifications::NullNotification)
     end
 
+    def seed_notification(seed, seed_used)
+      puts RSpec::Core::Notifications::SeedNotification.new(seed, seed_used).fully_formatted
+      puts
+    end
+
     protected
 
     def delegate_to_formatters(method, *args)

--- a/lib/turbo_tests/runner.rb
+++ b/lib/turbo_tests/runner.rb
@@ -20,7 +20,7 @@ module TurboTests
       verbose = opts.fetch(:verbose, false)
       fail_fast = opts.fetch(:fail_fast, nil)
       count = opts.fetch(:count, nil)
-      seed = opts.fetch(:seed, rand(0xFFFF).to_s)
+      seed = opts.fetch(:seed, nil) || rand(0xFFFF).to_s
       seed_used = !opts[:seed].nil?
 
       if verbose
@@ -102,11 +102,11 @@ module TurboTests
 
       @reporter.finish
 
+      @reporter.seed_notification(@seed, @seed_used)
+
       @threads.each(&:join)
 
       @reporter.failed_examples.empty? && wait_threads.map(&:value).all?(&:success?)
-
-      @reporter.seed_notification(@seed, @seed_used)
     end
 
     private

--- a/lib/turbo_tests/runner.rb
+++ b/lib/turbo_tests/runner.rb
@@ -20,7 +20,7 @@ module TurboTests
       verbose = opts.fetch(:verbose, false)
       fail_fast = opts.fetch(:fail_fast, nil)
       count = opts.fetch(:count, nil)
-      seed = opts.fetch(:seed, nil) || rand(0xFFFF).to_s
+      seed = opts.fetch(:seed, rand(0xFFFF).to_s)
       seed_used = !opts[:seed].nil?
 
       if verbose

--- a/lib/turbo_tests/runner.rb
+++ b/lib/turbo_tests/runner.rb
@@ -20,6 +20,8 @@ module TurboTests
       verbose = opts.fetch(:verbose, false)
       fail_fast = opts.fetch(:fail_fast, nil)
       count = opts.fetch(:count, nil)
+      seed = opts.fetch(:seed, rand(0xFFFF).to_s)
+      seed_used = !opts[:seed].nil?
 
       if verbose
         STDERR.puts "VERBOSE"
@@ -34,7 +36,9 @@ module TurboTests
         runtime_log: runtime_log,
         verbose: verbose,
         fail_fast: fail_fast,
-        count: count
+        count: count,
+        seed: seed,
+        seed_used: seed_used
       ).run
     end
 
@@ -49,6 +53,8 @@ module TurboTests
       @load_time = 0
       @load_count = 0
       @failure_count = 0
+      @seed = opts[:seed]
+      @seed_used = opts[:seed_used]
 
       @messages = Thread::Queue.new
       @threads = []
@@ -86,6 +92,8 @@ module TurboTests
 
       report_number_of_tests(tests_in_groups)
 
+      @reporter.seed_notification(@seed, @seed_used)
+
       wait_threads = tests_in_groups.map.with_index do |tests, process_id|
         start_regular_subprocess(tests, process_id + 1, **subprocess_opts)
       end
@@ -97,6 +105,8 @@ module TurboTests
       @threads.each(&:join)
 
       @reporter.failed_examples.empty? && wait_threads.map(&:value).all?(&:success?)
+
+      @reporter.seed_notification(@seed, @seed_used)
     end
 
     private
@@ -150,7 +160,7 @@ module TurboTests
         command = [
           ENV["BUNDLE_BIN_PATH"], "exec", "rspec",
           *extra_args,
-          "--seed", rand(0xFFFF).to_s,
+          "--seed", @seed,
           "--format", "TurboTests::JsonRowsFormatter",
           "--out", tmp_filename,
           *record_runtime_options,

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe TurboTests::CLI do
-  subject(:output) { `bundle exec turbo_tests -f d #{fixture}`.strip }
+  subject(:output) { `bundle exec turbo_tests -f d #{fixture} --seed 1234`.strip }
 
   before { output }
 
@@ -7,6 +7,9 @@ RSpec.describe TurboTests::CLI do
     let(:expected_start_of_output) {
       %(
 1 processes for 1 specs, ~ 1 specs per process
+
+Randomized with seed 1234
+
 
 An error occurred while loading #{fixture}.
 \e[31mFailure/Error: \e[0m\e[1;34m1\e[0m / \e[1;34m0\e[0m\e[0m
@@ -18,6 +21,11 @@ An error occurred while loading #{fixture}.
 \e[36m# #{fixture}:1:in `<top (required)>'\e[0m
 ).strip
     }
+    let(:expected_end_of_output) do
+      "0 examples, 0 failures\n"\
+        "\n\n"\
+        "Randomized with seed 1234"
+    end
 
     let(:fixture) { "./fixtures/rspec/errors_outside_of_examples_spec.rb" }
 
@@ -25,7 +33,7 @@ An error occurred while loading #{fixture}.
       expect($?.exitstatus).to eql(1)
 
       expect(output).to start_with(expected_start_of_output)
-      expect(output).to end_with("0 examples, 0 failures")
+      expect(output).to end_with(expected_end_of_output)
     end
   end
 
@@ -66,7 +74,7 @@ Fixture of spec file with pending failed examples is implemented but skipped wit
         expect(output).to include(part)
       end
 
-      expect(output).to end_with("3 examples, 0 failures, 3 pending")
+      expect(output).to end_with("3 examples, 0 failures, 3 pending\n\n\nRandomized with seed 1234")
     end
   end
 


### PR DESCRIPTION
Improve the reproducibility by allowing the user to define seeds. It can show randomly failing specs (I have had some project that had problem with those) failing only with specific seed.