### PR TITLE
Set bundler environmental variables when they are provided

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    turbo_tests (2.0.0)
+    turbo_tests (2.1.0)
       bundler (>= 2.1)
       parallel_tests (>= 3.3.0, < 5)
       rspec (>= 3.10)

--- a/lib/turbo_tests/runner.rb
+++ b/lib/turbo_tests/runner.rb
@@ -148,7 +148,7 @@ module TurboTests
           end
 
         command = [
-          ENV["BUNDLE_BIN_PATH"], "exec", "rspec",
+          "rspec",
           *extra_args,
           "--seed", rand(0xFFFF).to_s,
           "--format", "TurboTests::JsonRowsFormatter",
@@ -156,6 +156,7 @@ module TurboTests
           *record_runtime_options,
           *tests
         ]
+        command.unshift(ENV["BUNDLE_BIN_PATH"], "exec") if ENV["BUNDLE_BIN_PATH"]
 
         if @verbose
           command_str = [

--- a/lib/turbo_tests/version.rb
+++ b/lib/turbo_tests/version.rb
@@ -1,3 +1,3 @@
 module TurboTests
-  VERSION = "2.0.0"
+  VERSION = "2.1.0"
 end


### PR DESCRIPTION
Hello, I'm maintainer of RubyGems and Bundler.

Bundler repo vendored `turbo_tests` for our test suites like https://github.com/rubygems/rubygems/tree/master/bundler/tool/turbo_tests. I hope to use release version of `turbo_tests`, not vendoring. 

I removed `bundle exec` from commands builder of `turbo_tests` if they didn't use `turbo_tests` under the bundler because Bundler need to use `turbo_tests` without bundler environment.

How about this?

Thank you for develop this ❤️ 