### PR TITLE
Quote 3.0 in the CI configuration to avoid truncation.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        ruby: [ 2.7, 3.0, 3.1, 3.2 ]
+        ruby: [ 2.7, "3.0", 3.1, 3.2 ]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This PR quotes 3.0 to avoid truncation.  In the current configuration 3.0 is truncated to 3, and Ruby 3.2.x is loaded for this configuration entry which is not intended.