### PR TITLE
Handle Windows platform.

### DIFF
--- a/lib/turbo_tests/runner.rb
+++ b/lib/turbo_tests/runner.rb
@@ -131,7 +131,7 @@ module TurboTests
 
         begin
           File.mkfifo(tmp_filename)
-        rescue Errno::EEXIST
+        rescue Errno::EEXIST, NotImplementedError
         end
 
         env["RUBYOPT"] = ["-I#{File.expand_path("..", __dir__)}", ENV["RUBYOPT"]].compact.join(" ")


### PR DESCRIPTION
`File.mkfifo` is not implemented on Windows platform. So, RubyGems/Bundle team couldn't use `turbo_tests` with Windows platform.

see https://github.com/rubygems/rubygems/actions/runs/5252399613/jobs/9488415138#step:8:26

I simply catch `NotImplementedError` for this.