### PR TITLE
Support parallel_test options: pattern, exclude-pattern & group-by

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,12 @@ Options:
         --seed SEED                  Seed for rspec
 ```
 
+To pass any options supported by paralell_tests, use `--` :
+
+```bash
+bundle exec turbo_tests -n 4 -- --only-group 1 --pattern spec/system
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/turbo_tests/cli.rb
+++ b/lib/turbo_tests/cli.rb
@@ -98,15 +98,19 @@ module TurboTests
         end
       end
 
+      parallel_options = ParallelTests::CLI.new.send(:parse_options!, @argv.unshift("--type", "rspec"))
+      files = parallel_options.fetch(:files, ["spec"])
+
       exitstatus = TurboTests::Runner.run(
         formatters: formatters,
         tags: tags,
-        files: @argv.empty? ? ["spec"] : @argv,
+        files: files,
         runtime_log: runtime_log,
         verbose: verbose,
         fail_fast: fail_fast,
         count: count,
-        seed: seed
+        seed: seed,
+        parallel_options: parallel_options
       )
 
       # From https://github.com/serpapi/turbo_tests/pull/20/

--- a/lib/turbo_tests/runner.rb
+++ b/lib/turbo_tests/runner.rb
@@ -13,6 +13,7 @@ module TurboTests
       files = opts[:files]
       formatters = opts[:formatters]
       tags = opts[:tags]
+      parallel_options = opts[:parallel_options]
 
       start_time = opts.fetch(:start_time) { RSpec::Core::Time.now }
       runtime_log = opts.fetch(:runtime_log, nil)
@@ -38,6 +39,7 @@ module TurboTests
         count: count,
         seed: seed,
         seed_used: seed_used,
+        parallel_options: parallel_options
       ).run
     end
 
@@ -45,7 +47,6 @@ module TurboTests
       @reporter = opts[:reporter]
       @files = opts[:files]
       @tags = opts[:tags]
-      @runtime_log = opts[:runtime_log] || "tmp/turbo_rspec_runtime.log"
       @verbose = opts[:verbose]
       @fail_fast = opts[:fail_fast]
       @count = opts[:count]
@@ -55,6 +56,10 @@ module TurboTests
       @load_time = 0
       @load_count = 0
       @failure_count = 0
+
+      @runtime_log = opts[:runtime_log] || "tmp/turbo_rspec_runtime.log"
+      @parallel_options = opts.fetch(:parallel_options, {})
+      @parallel_options[:runtime_log] = @runtime_log
 
       @messages = Thread::Queue.new
       @threads = []
@@ -67,25 +72,15 @@ module TurboTests
         ParallelTests::RSpec::Runner.tests_with_size(@files, {}).size
       ].min
 
-      use_runtime_info = @files == ["spec"]
-
-      group_opts = {}
-
-      if use_runtime_info
-        group_opts[:runtime_log] = @runtime_log
-      else
-        group_opts[:group_by] = :filesize
-      end
-
       tests_in_groups =
         ParallelTests::RSpec::Runner.tests_in_groups(
           @files,
           @num_processes,
-          **group_opts
+          @parallel_options
         )
 
       subprocess_opts = {
-        record_runtime: use_runtime_info,
+        record_runtime: @parallel_options[:group_by] == :runtime
       }
 
       @reporter.report(tests_in_groups) do |reporter|


### PR DESCRIPTION
This PR adds suport for some parallel_test options:

```
    -p, --pattern [PATTERN]          run tests matching this regex pattern
        --exclude-pattern [PATTERN]  exclude tests matching this regex pattern
        --group-by [TYPE]            group tests by:
                                     found - order of finding files
                                     steps - number of cucumber/spinach steps
                                     scenarios - individual cucumber scenarios
                                     filesize - by size of the file
                                     runtime - info from runtime log
                                     default - runtime when runtime log is filled otherwise filesize
```

----

EDIT: See https://github.com/serpapi/turbo_tests/pull/41#issuecomment-2037723264

This PR will now adds suport to any options supported by parallel_tests.
You can pass these options after `--` :

```bash
bundle exec turbo_tests -n 4 -- --only-group 1 --pattern spec/system
```