### PR TITLE
Is bundler a dependency of turbo tests?

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,4 +26,4 @@ jobs:
       - name: Run tests
         timeout-minutes: 5
         run: |
-          ${{matrix.env}} bundle exec turbo_tests -n4
+          bundle exec turbo_tests -n4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: .
   specs:
     turbo_tests (2.1.1)
-      bundler (>= 2.1)
       parallel_tests (>= 3.3.0, < 5)
       rspec (>= 3.10)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,4 +41,4 @@ DEPENDENCIES
   turbo_tests!
 
 BUNDLED WITH
-   2.4.6
+   2.4.19

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    turbo_tests (2.1.1)
+    turbo_tests (2.2.0)
       parallel_tests (>= 3.3.0, < 5)
       rspec (>= 3.10)
 

--- a/lib/turbo_tests/version.rb
+++ b/lib/turbo_tests/version.rb
@@ -1,3 +1,3 @@
 module TurboTests
-  VERSION = "2.1.1"
+  VERSION = "2.2.0"
 end

--- a/turbo_tests.gemspec
+++ b/turbo_tests.gemspec
@@ -24,8 +24,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "pry", "~> 0.14"
 
-  spec.add_runtime_dependency "bundler", ">= 2.1"
-
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
   spec.files = Dir.chdir(File.expand_path("..", __FILE__)) do


### PR DESCRIPTION
I'm trying to add turbo tests to dependabot-core at https://github.com/dependabot/dependabot-core/pull/8092, but I'm getting an issue due to the dependency on Bundler.

So this is a question-PR. Does turbo tests actually depend on Bundler?