### PR TITLE
Remove OpenStruct usage with Struct replacement

### DIFF
--- a/lib/turbo_tests.rb
+++ b/lib/turbo_tests.rb
@@ -2,7 +2,6 @@
 
 require "open3"
 require "fileutils"
-require "ostruct"
 require "json"
 require "rspec"
 

--- a/lib/utils/hash_extension.rb
+++ b/lib/utils/hash_extension.rb
@@ -1,9 +1,7 @@
 module CoreExtensions
   refine Hash do
     def to_struct
-      OpenStruct.new(self.each_with_object({}) do |(key, val), acc|
-        acc[key] = val.is_a?(Hash) ? val.to_struct : val
-      end)
+      Struct.new(*self.keys).new(*self.values.map { |value| value.is_a?(Hash) ? value.to_struct : value })
     end
   end
 end


### PR DESCRIPTION
This replacement to use a struct should still resolve the original issue in #49 but also with https://github.com/serpapi/turbo_tests/pull/49#issuecomment-2057132440 for the reported ruby core issue.

Example you can try in an IRB console:

```ruby
data = {
  a: 1,
  b: 2,
  c: {
    d: 3,
    e: {
      f: 4,
      g: 5
    }
  }
}

class Hash
  def to_struct
    Struct.new(*self.keys).new(*self.values.map { |value| value.is_a?(Hash) ? value.to_struct : value })
  end
end

result = data.to_struct
```