### PR TITLE
Feature/support   profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@
 # rspec failure tracking
 .rspec_status
 
-
 # Created by https://www.toptal.com/developers/gitignore/api/macos,vim
 # Edit at https://www.toptal.com/developers/gitignore?templates=macos,vim
 
@@ -22,7 +21,6 @@
 
 # Icon must end with two \r
 Icon
-
 
 # Thumbnails
 ._*
@@ -46,7 +44,7 @@ Temporary Items
 ### Vim ###
 # Swap
 [._]*.s[a-v][a-z]
-!*.svg  # comment out if you don't need vector files
+!*.svg # comment out if you don't need vector files
 [._]*.sw[a-p]
 [._]s[a-rt-v][a-z]
 [._]ss[a-gi-z]
@@ -66,3 +64,4 @@ tags
 
 # End of https://www.toptal.com/developers/gitignore/api/macos,vim
 
+.ruby-version

--- a/fixtures/rspec/6_tests_spec.rb
+++ b/fixtures/rspec/6_tests_spec.rb
@@ -1,0 +1,26 @@
+
+RSpec.describe "Failing example group" do
+  context "When more than 10 tests" do  
+    context "when it has 6 tests" do
+      it "has a version number" do
+        expect(TurboTests::VERSION).not_to be nil
+      end
+      it "has a version number" do
+        expect(TurboTests::VERSION).not_to be nil
+      end
+      it "has a version number" do
+        expect(TurboTests::VERSION).not_to be nil
+      end
+      it "has a version number" do
+        expect(TurboTests::VERSION).not_to be nil
+      end
+      it "has a version number" do
+        expect(TurboTests::VERSION).not_to be nil
+      end
+      it "has a version number" do
+        expect(TurboTests::VERSION).not_to be nil
+      end
+    end
+  end
+end
+

--- a/fixtures/rspec/another_6_tests_spec.rb
+++ b/fixtures/rspec/another_6_tests_spec.rb
@@ -1,0 +1,26 @@
+
+RSpec.describe "Failing example group" do
+  context "When more than 10 tests" do  
+    context "when it has another 6 tests" do
+      it "has a version number" do
+        expect(TurboTests::VERSION).not_to be nil
+      end
+      it "has a version number" do
+        expect(TurboTests::VERSION).not_to be nil
+      end
+      it "has a version number" do
+        expect(TurboTests::VERSION).not_to be nil
+      end
+      it "has a version number" do
+        expect(TurboTests::VERSION).not_to be nil
+      end
+      it "has a version number" do
+        expect(TurboTests::VERSION).not_to be nil
+      end
+      it "has a version number" do
+        expect(TurboTests::VERSION).not_to be nil
+      end
+    end 
+  end
+end
+

--- a/lib/turbo_tests/cli.rb
+++ b/lib/turbo_tests/cli.rb
@@ -83,7 +83,7 @@ module TurboTests
           seed = s
         end
 
-        opts.on("--profile N", "Slowest N tests per thread") do |n|
+        opts.on("--profile N", "Slowest N tests") do |n|
           n = begin
             Integer(n)
           rescue

--- a/lib/turbo_tests/cli.rb
+++ b/lib/turbo_tests/cli.rb
@@ -17,6 +17,7 @@ module TurboTests
       verbose = false
       fail_fast = nil
       seed = nil
+      profile = nil
 
       OptionParser.new { |opts|
         opts.banner = <<~BANNER
@@ -81,6 +82,15 @@ module TurboTests
         opts.on("--seed SEED", "Seed for rspec") do |s|
           seed = s
         end
+
+        opts.on("--profile N", "Slowest N tests per thread") do |n|
+          n = begin
+            Integer(n)
+          rescue
+            raise ArgumentError, "Invalid argument for --profile. Must be an integer."
+          end
+          profile = n
+        end
       }.parse!(@argv)
 
       requires.each { |f| require(f) }
@@ -99,14 +109,15 @@ module TurboTests
       end
 
       exitstatus = TurboTests::Runner.run(
-        formatters: formatters,
-        tags: tags,
+        formatters:,
+        tags:,
         files: @argv.empty? ? ["spec"] : @argv,
-        runtime_log: runtime_log,
-        verbose: verbose,
-        fail_fast: fail_fast,
-        count: count,
-        seed: seed
+        runtime_log:,
+        verbose:,
+        fail_fast:,
+        count:,
+        seed:,
+        profile:
       )
 
       # From https://github.com/serpapi/turbo_tests/pull/20/

--- a/lib/turbo_tests/json_rows_formatter.rb
+++ b/lib/turbo_tests/json_rows_formatter.rb
@@ -122,13 +122,16 @@ module TurboTests
       end
     end
 
+    ExampleExecutionResult = Struct.new(:example_skipped?, :pending_message, :status, :pending_fixed?, :exception, :run_time)
+
     def execution_result_to_json(result)
       {
         example_skipped?: result.example_skipped?,
         pending_message: result.pending_message,
         status: result.status,
         pending_fixed?: result.pending_fixed?,
-        exception: exception_to_json(result.exception || result.pending_exception)
+        exception: exception_to_json(result.exception || result.pending_exception),
+        run_time: result.run_time
       }
     end
 
@@ -138,6 +141,8 @@ module TurboTests
         inclusion_location: frame.inclusion_location
       }
     end
+    
+    Example = Struct.new(:execution_result, :location, :description, :full_description, :metadata, :location_rerun_argument)
 
     def example_to_json(example)
       {
@@ -166,10 +171,11 @@ module TurboTests
     def dump_profile_to_json(notification)
       {
         duration: notification.duration,
-        examples: notification.examples,
-        # example_groups: notification.example_groups
+        examples: notification.examples.map { |example| example_to_json(example) },
       }
     end
+
+    Group = Struct.new(:description, :location, :total_time, :count, :average)
 
     def group_to_json(notification)
       {

--- a/lib/turbo_tests/json_rows_formatter.rb
+++ b/lib/turbo_tests/json_rows_formatter.rb
@@ -25,6 +25,7 @@ module TurboTests
       :start,
       :close,
       :example_failed,
+      :dump_profile,
       :example_passed,
       :example_pending,
       :example_group_started,
@@ -43,6 +44,13 @@ module TurboTests
       output_row(
         type: :load_summary,
         summary: load_summary_to_json(notification)
+      )
+    end
+
+    def dump_profile(notification)
+      output_row(
+        type: :dump_profile,
+        dump_profile: dump_profile_to_json(notification)
       )
     end
 
@@ -152,6 +160,14 @@ module TurboTests
       {
         count: notification.count,
         load_time: notification.load_time,
+      }
+    end
+
+    def dump_profile_to_json(notification)
+      {
+        duration: notification.duration,
+        examples: notification.examples,
+        # example_groups: notification.example_groups
       }
     end
 

--- a/lib/turbo_tests/reporter.rb
+++ b/lib/turbo_tests/reporter.rb
@@ -4,8 +4,8 @@ module TurboTests
   class Reporter
     attr_writer :load_time
 
-    def self.from_config(formatter_config, start_time, seed, seed_used)
-      reporter = new(start_time, seed, seed_used)
+    def self.from_config(formatter_config, start_time, seed, seed_used, profile)
+      reporter = new(start_time, seed, seed_used, profile)
 
       formatter_config.each do |config|
         name, outputs = config.values_at(:name, :outputs)
@@ -23,10 +23,11 @@ module TurboTests
     attr_reader :pending_examples
     attr_reader :failed_examples
 
-    def initialize(start_time, seed, seed_used)
+    def initialize(start_time, seed, seed_used, profile)
       @formatters = []
       @pending_examples = []
       @failed_examples = []
+      @profile = profile
       @all_examples = []
       @all_profile_examples = []
       @all_profile_groups = {}
@@ -173,7 +174,7 @@ module TurboTests
               execution_result: JsonRowsFormatter::ExampleExecutionResult.new(**e[:execution_result])
             ) 
           end,
-          @all_profile_examples.count,
+          @profile,
           @all_profile_groups
         )) if @all_profile_examples.any?
       delegate_to_formatters(:seed,

--- a/lib/turbo_tests/reporter.rb
+++ b/lib/turbo_tests/reporter.rb
@@ -28,6 +28,9 @@ module TurboTests
       @pending_examples = []
       @failed_examples = []
       @all_examples = []
+      @all_profile_examples = []
+      @all_profile_groups = []
+      @profile_time = 0
       @messages = []
       @start_time = start_time
       @seed = seed
@@ -112,6 +115,12 @@ module TurboTests
       @failed_examples << example
     end
 
+    def dump_profile(profile)
+      @all_profile_examples += profile[:examples] || []
+      @all_profile_groups += profile[:groups] || []
+      @profile_time += profile[:duration] || 0
+    end
+
     def message(message)
       delegate_to_formatters(:message, RSpec::Core::Notifications::MessageNotification.new(message))
       @messages << message
@@ -146,6 +155,13 @@ module TurboTests
           @load_time,
           @errors_outside_of_examples_count
         ))
+      delegate_to_formatters(:dump_profile,
+        RSpec::Core::Notifications::ProfileNotification.new(
+          @profile_time,
+          @all_profile_examples,
+          @all_profile_examples.count,
+          @all_profile_groups
+        )) if @all_profile_examples.any?
       delegate_to_formatters(:seed,
         RSpec::Core::Notifications::SeedNotification.new(
           @seed,

--- a/lib/turbo_tests/reporter.rb
+++ b/lib/turbo_tests/reporter.rb
@@ -119,7 +119,6 @@ module TurboTests
     end
 
     def dump_profile(profile)
-      pp  profile[:examples]
       group = JsonRowsFormatter::Group.new(
         # TODO: this isnt correct, but we cant seem to access the existing group info as its private 
         location:  profile[:examples].map { |e| e[:location].split(":").first }.uniq.join(", "),

--- a/lib/turbo_tests/reporter.rb
+++ b/lib/turbo_tests/reporter.rb
@@ -119,10 +119,11 @@ module TurboTests
     end
 
     def dump_profile(profile)
+      pp  profile[:examples]
       group = JsonRowsFormatter::Group.new(
-        # TODO: this isnt the most accurate
-        location:  profile[:examples].reduce("") { |acc, e| "#{acc}#{e[:location]}, " }.chomp(", "),
-        description: profile[:examples].reduce("") { |acc, e| "#{acc}#{e[:description]}, " }.chomp(", "),
+        # TODO: this isnt correct, but we cant seem to access the existing group info as its private 
+        location:  profile[:examples].map { |e| e[:location].split(":").first }.uniq.join(", "),
+        description: "Group #{@all_profile_groups.keys.count + 1}",
         count: profile[:examples].count,
         total_time: profile[:examples].sum { |e| e[:execution_result][:run_time] },
       )

--- a/lib/turbo_tests/reporter.rb
+++ b/lib/turbo_tests/reporter.rb
@@ -47,6 +47,8 @@ module TurboTests
             RSpec::Core::Formatters::ProgressFormatter
           when "d", "documentation"
             RSpec::Core::Formatters::DocumentationFormatter
+          when "profile"
+            RSpec::Core::Formatters::ProfileFormatter
           else
             Kernel.const_get(name)
           end

--- a/lib/turbo_tests/runner.rb
+++ b/lib/turbo_tests/runner.rb
@@ -29,7 +29,7 @@ module TurboTests
         warn "VERBOSE"
       end
 
-      reporter = Reporter.from_config(formatters, start_time, seed, seed_used)
+      reporter = Reporter.from_config(formatters, start_time, seed, seed_used, profile)
 
       new(
         reporter:,

--- a/lib/turbo_tests/runner.rb
+++ b/lib/turbo_tests/runner.rb
@@ -243,10 +243,13 @@ module TurboTests
 
     def handle_messages
       exited = 0
-
+      
       loop do
         message = @messages.pop
         case message[:type]
+        when "dump_profile"
+          message.inspect
+          @reporter.dump_profile(message[:dump_profile])
         when "example_passed"
           example = FakeExample.from_obj(message[:example])
           @reporter.example_passed(example)

--- a/lib/turbo_tests/runner.rb
+++ b/lib/turbo_tests/runner.rb
@@ -250,7 +250,6 @@ module TurboTests
         message = @messages.pop
         case message[:type]
         when "dump_profile"
-          message.inspect
           @reporter.dump_profile(message[:dump_profile])
         when "example_passed"
           example = FakeExample.from_obj(message[:example])

--- a/lib/turbo_tests/runner.rb
+++ b/lib/turbo_tests/runner.rb
@@ -23,6 +23,8 @@ module TurboTests
       profile = opts.fetch(:profile)
       seed_used = !seed.nil?
 
+      formatters << { name: "profile", outputs: ["-"] } unless profile.nil?
+
       if verbose
         warn "VERBOSE"
       end

--- a/lib/turbo_tests/runner.rb
+++ b/lib/turbo_tests/runner.rb
@@ -20,6 +20,7 @@ module TurboTests
       fail_fast = opts.fetch(:fail_fast, nil)
       count = opts.fetch(:count, nil)
       seed = opts.fetch(:seed)
+      profile = opts.fetch(:profile)
       seed_used = !seed.nil?
 
       if verbose
@@ -29,15 +30,16 @@ module TurboTests
       reporter = Reporter.from_config(formatters, start_time, seed, seed_used)
 
       new(
-        reporter: reporter,
-        files: files,
-        tags: tags,
-        runtime_log: runtime_log,
-        verbose: verbose,
-        fail_fast: fail_fast,
-        count: count,
-        seed: seed,
-        seed_used: seed_used,
+        reporter:,
+        files:,
+        tags:,
+        runtime_log:,
+        verbose:,
+        fail_fast:,
+        count:,
+        seed:,
+        seed_used:,
+        profile:
       ).run
     end
 
@@ -50,6 +52,7 @@ module TurboTests
       @fail_fast = opts[:fail_fast]
       @count = opts[:count]
       @seed = opts[:seed]
+      @profile = opts[:profile]
       @seed_used = opts[:seed_used]
 
       @load_time = 0
@@ -164,10 +167,19 @@ module TurboTests
           []
         end
 
+        profile_option = if @profile
+          [
+            "--profile", @profile.to_s,
+          ]
+        else
+          []
+        end
+
         command = [
           *command_name,
           *extra_args,
           *seed_option,
+          *profile_option,
           "--format", "TurboTests::JsonRowsFormatter",
           *record_runtime_options,
           *tests,

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe TurboTests::CLI do
       end
     end
 
-    context "reports the combined total of profile" do
+    context "reports the combined total of profile, but only shows max --profile" do
       subject(:output) { `bundle exec turbo_tests  #{fixture} --profile #{profile}`.strip }
 
       let(:fixture) { "./fixtures/rspec/6_tests_spec.rb ./fixtures/rspec/another_6_tests_spec.rb" }
@@ -30,7 +30,7 @@ RSpec.describe TurboTests::CLI do
 
         [
           "12 examples, 0 failures",
-          "Top 12 slowest examples",
+          "Top #{profile} slowest examples",
           "Top 2 slowest example groups",
         ].each do |part|
           expect(output).to include(part).exactly(1).times

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -14,60 +14,47 @@ RSpec.describe TurboTests::CLI do
       let(:profile) { "sadasd" }
 
       it "converts to integer" do
-        expect{ output }.to raise_error(ArgumentError, "Invalid argument for --profile. Must be an integer.")
+        expect { output }.to raise_error(ArgumentError, "Invalid argument for --profile. Must be an integer.")
       end
     end
 
-    context "errors outside of examples" do
-      let(:expected_start_of_output) {
-%(
-1 processes for 1 specs, ~ 1 specs per process
+    context "reports the combined total of profile" do
+      subject(:output) { `bundle exec turbo_tests  #{fixture} --profile #{profile}`.strip }
 
-An error occurred while loading #{fixture}.
-\e[31mFailure/Error: \e[0m\e[1;34m1\e[0m / \e[1;34m0\e[0m\e[0m
-\e[31m\e[0m
-\e[31mZeroDivisionError:\e[0m
-\e[31m  divided by 0\e[0m
-\e[36m# #{fixture}:4:in `/'\e[0m
-\e[36m# #{fixture}:4:in `block in <top (required)>'\e[0m
-\e[36m# #{fixture}:1:in `<top (required)>'\e[0m
-).strip
-      }
+      let(:fixture) { "./fixtures/rspec/6_tests_spec.rb ./fixtures/rspec/another_6_tests_spec.rb" }
 
-      let(:expected_end_of_output) do
-        "0 examples, 0 failures, 1 error occurred outside of examples"
-      end
+      let(:profile) { 10 }
 
-      let(:fixture) { "./fixtures/rspec/errors_outside_of_examples_spec.rb" }
+      it do
+        expect($?.exitstatus).to eql(0)
 
-      it "reports" do
-        expect($?.exitstatus).to eql(1)
-
-        expect(output).to start_with(expected_start_of_output)
-        expect(output).to include("Top 10 slowest examples").exactly(1).times
-        expect(output).to include("slowest example groups").exactly(1).times
-        expect(output).to end_with(expected_end_of_output)
+        [
+          "12 examples, 0 failures",
+          "Top 12 slowest examples",
+          "Top 2 slowest example groups",
+        ].each do |part|
+          expect(output).to include(part).exactly(1).times
+        end
       end
     end
 
     context "pending exceptions", :aggregate_failures do
       let(:fixture) { "./fixtures/rspec/pending_exceptions_spec.rb" }
 
-      it "reports" do
+      it "reports, doesnt include group when only 1 group" do
         expect($?.exitstatus).to eql(0)
 
         [
           "is implemented but skipped with 'pending' (PENDING: TODO: skipped with 'pending')",
           "is implemented but skipped with 'skip' (PENDING: TODO: skipped with 'skip')",
           "is implemented but skipped with 'xit' (PENDING: Temporarily skipped with xit)",
-          "Top 10 slowest examples",
-          "slowest example groups",
+          "slowest examples",
+          "3 examples, 0 failures, 3 pending",
           "Pending: (Failures listed here are expected and do not affect your suite's status)",
         ].each do |part|
           expect(output).to include(part).exactly(1).times
         end
-
-        expect(output).to end_with("3 examples, 0 failures, 3 pending")
+        expect(output).not_to include("slowest example groups")
       end
     end
   end


### PR DESCRIPTION
closes https://github.com/serpapi/turbo_tests/issues/39

* adds support for the --profile, only accepts string wrapped ints or will scream.
* combines each threads slowest into 1 total i.e if 3 threads you will be served the slowest 10 not 30
* added specs to try and test this

Questions:
* i had a hard time actually building the required struct for the profile formatter as unlike the others it uses the provided params as objects instead of just being  a string like i.e dump_summary
* i couldn't actually workout a nice place to get the list of example groups from so atm it will just get all unique file locations and and descriptions based on count of how many gorups
* i cant seem to get the exception of raising of the argument error?

<img width="1140" alt="image" src="https://github.com/user-attachments/assets/a2058f51-1451-49ed-a5b4-d5395f250849">


@ilyazub i had a crack i know this is close, but it does feel like ive hacked it a bit open to any feedback!