### PR TITLE
Use PARALLEL_TESTS_EXECUTABLE environmental variable if it's provided

### DIFF
--- a/lib/turbo_tests/runner.rb
+++ b/lib/turbo_tests/runner.rb
@@ -140,7 +140,9 @@ module TurboTests
         env["RUBYOPT"] = ["-I#{File.expand_path("..", __dir__)}", ENV["RUBYOPT"]].compact.join(" ")
         env["RSPEC_SILENCE_FILTER_ANNOUNCEMENTS"] = "1"
 
-        if ENV["BUNDLE_BIN_PATH"]
+        if ENV["PARALLEL_TESTS_EXECUTABLE"]
+          command_name = ENV["PARALLEL_TESTS_EXECUTABLE"].split
+        elsif ENV["BUNDLE_BIN_PATH"]
           command_name = [ENV["BUNDLE_BIN_PATH"], "exec", "rspec"]
         else
           command_name = "rspec"

--- a/lib/turbo_tests/runner.rb
+++ b/lib/turbo_tests/runner.rb
@@ -140,8 +140,8 @@ module TurboTests
         env["RUBYOPT"] = ["-I#{File.expand_path("..", __dir__)}", ENV["RUBYOPT"]].compact.join(" ")
         env["RSPEC_SILENCE_FILTER_ANNOUNCEMENTS"] = "1"
 
-        if ENV["PARALLEL_TESTS_EXECUTABLE"]
-          command_name = ENV["PARALLEL_TESTS_EXECUTABLE"].split
+        if ENV["RSPEC_EXECUTABLE"]
+          command_name = ENV["RSPEC_EXECUTABLE"].split
         elsif ENV["BUNDLE_BIN_PATH"]
           command_name = [ENV["BUNDLE_BIN_PATH"], "exec", "rspec"]
         else


### PR DESCRIPTION
👋 Thank you for maintaining `turbo_tests`.

I would like to use `turbo_tests` on `ruby/ruby` same as `rubygems/rubygems` for testing bundler. see https://github.com/ruby/ruby/pull/12250.

We used `parallel_tests` because `turbo_tests` didn't support `ENV["PARALLEL_TESTS_EXECUTABLE"]` for custom executable on `parallel_tests`. I added new condition for that around `command_name`.

How about this? Thank you for reading this.