### PR TITLE
Removed unnecessary setup code

### DIFF
--- a/lib/turbo_tests/runner.rb
+++ b/lib/turbo_tests/runner.rb
@@ -84,8 +84,6 @@ module TurboTests
           **group_opts
         )
 
-      setup_tmp_dir
-
       subprocess_opts = {
         record_runtime: use_runtime_info,
       }
@@ -109,15 +107,6 @@ module TurboTests
     end
 
     private
-
-    def setup_tmp_dir
-      begin
-        FileUtils.rm_r("tmp/test-pipes")
-      rescue Errno::ENOENT
-      end
-
-      FileUtils.mkdir_p("tmp/test-pipes/")
-    end
 
     def start_regular_subprocess(tests, process_id, **opts)
       start_subprocess(


### PR DESCRIPTION
`tmp/test-pipes` is no longer needed from https://github.com/serpapi/turbo_tests/commit/b4ad8f4f6fdf4174d41cb835a858a7b446521e55. I removed that.