### PR TITLE
Support for RSpec Junit reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,17 @@ Execute tests:
 $ bundle exec turbo_tests
 ```
 
+To enable support for RSpec Junit formatting (ie for CircleCI), include `rspec_junit_formatter` in Gemfile, and pass the `-r rspec_junit_formatter` option. Output will be written to `rspec/rspec#{TEST_ENV_NUMBER}.xml` files. Update your Circle CI config:
+
+```yml
+# .circleci/config.yml
+- run: 
+    name: RSpec
+    command: bundle exec turbo_tests -r rspec_junit_formatter
+- store_test_results:
+    path: rspec
+```
+
 Show help:
 
 ```bash

--- a/lib/turbo_tests/runner.rb
+++ b/lib/turbo_tests/runner.rb
@@ -155,11 +155,21 @@ module TurboTests
           []
         end
 
+        junit_options = if defined?(RspecJunitFormatter)
+          [
+            "--format", "RspecJunitFormatter",
+            "--out", "rspec/rspec#{process_id}.xml"
+          ]
+        else
+          []
+        end
+
         command = [
           *command_name,
           *extra_args,
           *seed_option,
           "--format", "TurboTests::JsonRowsFormatter",
+          *junit_options,
           *record_runtime_options,
           *tests,
         ]


### PR DESCRIPTION
This adds support for Junit reporting. It seems the current design of turbo tests is not able to work with RSpec Junit, no matter what args or configuration I try. This is important for CircleCI. I work on a couple projects using `parallel_tests` in Circle, but it would be nice to have consolidated log output with failures listed together, as turbo_tests does. However, switching to turbo_tests removes the failing tests from the `Tests` tab in Circle (see working example below). Getting RSpec Junit to work makes it possible to use turbo tests in Circle and still extract the failures into that tab

![Image 6-7-25 at 8 03 AM](https://github.com/user-attachments/assets/62131a55-07c1-4329-ad78-791b11c0a566)
