### PR TITLE
Update gemspec to allow v5 of the parallel_tests gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     turbo_tests (2.2.5)
-      parallel_tests (>= 3.3.0, < 5)
+      parallel_tests (>= 3.3.0, < 6)
       rspec (>= 3.10)
 
 GEM

--- a/turbo_tests.gemspec
+++ b/turbo_tests.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.7"
 
   spec.add_dependency "rspec", ">= 3.10"
-  spec.add_dependency "parallel_tests", ">= 3.3.0", "< 5"
+  spec.add_dependency "parallel_tests", ">= 3.3.0", "< 6"
 
   spec.add_development_dependency "pry", "~> 0.14"
 


### PR DESCRIPTION
This allows keeping updated with the latest version of `parallel_tests`. Tests pass and there seems to be no reason to not allow this